### PR TITLE
Renamed FrameworkContext to TokenContext 

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ class DefaultController
 }
 ```
 
-## Inject FrameworkContext into actions
+## Inject TokenContext into actions
 
 In Symfony access to security related information is available through the
 `security.context` service.  This is bad from a design perspective, because it
@@ -198,7 +198,7 @@ is needed.
 To avoid access to the security state from a service, it needs to be passed as
 arguments, starting with the controller action.
 
-That is what the `FrameworkContext` class is for. Just add a typehint for it to
+That is what the `TokenContext` class is for. Just add a typehint for it to
 any action and NoFrameworkBundle will pass this object into your action. From
 it you have access to various security related methods:
 
@@ -207,11 +207,11 @@ it you have access to various security related methods:
 # src/Acme/DemoBundle/Controller/DefaultController.php
 namespace Acme\DemoBundle\Controller;
 
-use QafooLabs\MVC\FrameworkContext;
+use QafooLabs\MVC\TokenContext;
 
 class DefaultController
 {
-    public function redirectAction(FrameworkContext $context)
+    public function redirectAction(TokenContext $context)
     {
         if ($context->hasToken()) {
             $user = $context->getCurrentUser();
@@ -228,10 +228,10 @@ class DefaultController
 }
 ```
 
-For Symfony a concrete implementation `SymfonyFrameworkContext` is used for the
+For Symfony a concrete implementation `SymfonyTokenContext` is used for the
 interface that uses `security.context` internally.
 
-In unit tests where you want to test the controller you can use the `MockFrameworkContext`
+In unit tests where you want to test the controller you can use the `MockTokenContext`
 instead. It doesnt work with complex `isGranted()` checks or the token, but if you only
 use the user object it allows very simple test setup.
 

--- a/design/token_context.md
+++ b/design/token_context.md
@@ -1,4 +1,4 @@
-# Framework Context
+# Token Context
 
 Context should be made explicit by using a *ContextObject* passed as parameter
 into methods. Symfony however passes context around through services such as
@@ -6,7 +6,7 @@ into methods. Symfony however passes context around through services such as
 very hard to test.  Inside Twig however this context object exists with the
 magic `app` variable.
 
-We propose to introduce a `FrameworkContext` object that can be injected
+We propose to introduce a `TokenContext` object that can be injected
 into controllers using the ParamConverter mechanism:
 
 ```php
@@ -16,7 +16,7 @@ namespace Acme\DemoBundle\Controller;
 
 class DefaultController
 {
-    public function helloAction(FrameworkContext $context)
+    public function helloAction(TokenContext $context)
     {
         retun array('name' => $context->getCurrentUsername());
     }
@@ -27,7 +27,7 @@ The interface for this context is:
 
 ```php
 <?php
-interface FrameworkContext
+interface TokenContext
 {
     /**
      * If a security context and token exists, retrieve the username.

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use QafooLabs\Bundle\NoFrameworkBundle\SymfonyFlashBag;
 use QafooLabs\Bundle\NoFrameworkBundle\Request\SymfonyFormRequest;
-use QafooLabs\Bundle\NoFrameworkBundle\SymfonyFrameworkContext;
+use QafooLabs\Bundle\NoFrameworkBundle\SymfonyTokenContext;
 
 /**
  * Convert the request parameters into objects when typehinted.
@@ -54,8 +54,8 @@ class ParamConverterListener
                 $value = $request->getSession();
             } else if ("QafooLabs\\MVC\\FormRequest" === $class) {
                 $value = new SymfonyFormRequest($request, $this->container->get('form.factory'));
-            } else if ("QafooLabs\\MVC\\FrameworkContext" === $class) {
-                $value = new SymfonyFrameworkContext(
+            } else if ("QafooLabs\\MVC\\TokenContext" === $class) {
+                $value = new SymfonyTokenContext(
                     $this->container->get('security.context')
                 );
             } else {

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/MockTokenContext.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/MockTokenContext.php
@@ -2,13 +2,13 @@
 
 namespace QafooLabs\Bundle\NoFrameworkBundle;
 
-use QafooLabs\MVC\FrameworkContext;
+use QafooLabs\MVC\TokenContext;
 use QafooLabs\MVC\Exception;
 
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class MockFrameworkContext implements FrameworkContext
+class MockTokenContext implements TokenContext
 {
     private $user;
     private $token;
@@ -72,7 +72,7 @@ class MockFrameworkContext implements FrameworkContext
 
     public function getToken()
     {
-        throw new \BadMethodCallException("getToken() not supported in MockFrameworkContext");
+        throw new \BadMethodCallException("getToken() not supported in MockTokenContext");
     }
 
     public function isGranted($attributes, $object = null)

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
@@ -2,13 +2,13 @@
 
 namespace QafooLabs\Bundle\NoFrameworkBundle;
 
-use QafooLabs\MVC\FrameworkContext;
+use QafooLabs\MVC\TokenContext;
 use QafooLabs\MVC\Exception;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
-class SymfonyFrameworkContext implements FrameworkContext
+class SymfonyTokenContext implements TokenContext
 {
     private $securityContext;
 

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
@@ -3,7 +3,7 @@
 namespace QafooLabs\Bundle\NoFrameworkBundle\Tests\EventListener;
 
 use QafooLabs\Bundle\NoFrameworkBundle\EventListener\ParamConverterListener;
-use QafooLabs\MVC\FrameworkContext;
+use QafooLabs\MVC\TokenContext;
 use QafooLabs\MVC\Flash;
 
 use Symfony\Component\DependencyInjection\Container;
@@ -37,7 +37,7 @@ class ParamConverterListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->attributes->has('session'));
     }
 
-    public function someAction(Session $session, FrameworkContext $context, Flash $flash)
+    public function someAction(Session $session, TokenContext $context, Flash $flash)
     {
     }
 }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/MockTokenContextTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/MockTokenContextTest.php
@@ -2,9 +2,9 @@
 
 namespace QafooLabs\Bundle\NoFrameworkBundle\Tests;
 
-use QafooLabs\Bundle\NoFrameworkBundle\MockFrameworkContext;
+use QafooLabs\Bundle\NoFrameworkBundle\MockTokenContext;
 
-class MockFrameworkContextTest extends \PHPUnit_Framework_TestCase
+class MockTokenContextTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -14,7 +14,7 @@ class MockFrameworkContextTest extends \PHPUnit_Framework_TestCase
         $user = \Phake::mock('Symfony\Component\Security\Core\User\UserInterface');
         \Phake::when($user)->getRoles()->thenReturn(array('ROLE_USER', 'ROLE_ADMIN'));
 
-        $context = new MockFrameworkContext($user);
+        $context = new MockTokenContext($user);
 
         $this->assertTrue($context->isGranted('ROLE_USER'));
     }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/SymfonyTokenContextTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/SymfonyTokenContextTest.php
@@ -2,9 +2,9 @@
 
 namespace QafooLabs\Bundle\NoFrameworkBundle\Tests;
 
-use QafooLabs\Bundle\NoFrameworkBundle\SymfonyFrameworkContext;
+use QafooLabs\Bundle\NoFrameworkBundle\SymfonyTokenContext;
 
-class SymfonyFrameworkContextTest extends \PHPUnit_Framework_TestCase
+class SymfonyTokenContextTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -13,7 +13,7 @@ class SymfonyFrameworkContextTest extends \PHPUnit_Framework_TestCase
     {
         $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
         $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyFrameworkContext($security, 'dev', true);
+        $context = new SymfonyTokenContext($security, 'dev', true);
 
         \Phake::when($security)->getToken()->thenReturn($token);
 
@@ -28,7 +28,7 @@ class SymfonyFrameworkContextTest extends \PHPUnit_Framework_TestCase
     {
         $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
         $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyFrameworkContext($security, 'dev', true);
+        $context = new SymfonyTokenContext($security, 'dev', true);
 
         $this->setExpectedException('QafooLabs\MVC\Exception\UnauthenticatedUserException');
 
@@ -42,7 +42,7 @@ class SymfonyFrameworkContextTest extends \PHPUnit_Framework_TestCase
     {
         $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
         $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyFrameworkContext($security, 'dev', true);
+        $context = new SymfonyTokenContext($security, 'dev', true);
 
         $this->assertFalse($context->hasToken());
     }

--- a/src/QafooLabs/MVC/TokenContext.php
+++ b/src/QafooLabs/MVC/TokenContext.php
@@ -2,7 +2,7 @@
 
 namespace QafooLabs\MVC;
 
-interface FrameworkContext
+interface TokenContext
 {
     /**
      * If a security context and token exists, retrieve the user id.


### PR DESCRIPTION
Renamed FrameworkContext to TokenContext including all related classes, documentation and tests.

Following a suggestion at symfony live 2014 in Berlin, this commit renames the FrameworkContext to TokenContext. I hope, that I found every related occurrence outside the usual code - so documentation, test classes, typehints are affected as well.

As a side note: All tests still pass, but I had to switch to the dev version of phake, because it threw serialisation errors in its current stable version (see https://github.com/mlively/Phake/issues/155). It does so in the master branch of the NoFrameworkBundle as well, so it has nothing to do with the introduced name changes.
