### PR TITLE
fix user id access

### DIFF
--- a/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
@@ -27,7 +27,7 @@ class SymfonyTokenContext implements TokenContext
      */
     public function getCurrentUserId()
     {
-        return $this->getUser()->getId();
+        return $this->getCurrentUser()->getId();
     }
 
     /**


### PR DESCRIPTION
Method `getUser()` does not exist but `getCurrentUser()` does.
