### PR TITLE
Make framework bundle optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,21 @@
         {"name": "Benjamin Eberlei", "email": "benjamin@qafoo.com"},
         {"name": "Manuel Pichler", "email": "manuel@qafoo.com"}
     ],
-    "require": {
-        "symfony/framework-bundle": "~2.1",
-        "sensio/framework-extra-bundle": "~3.0"
-    },
     "require-dev": {
         "phake/phake": "@stable",
         "symfony/form": "@stable",
-        "jms/serializer": "@stable"
+        "jms/serializer": "@stable",
+        "symfony/framework-bundle": "~2.1",
+        "sensio/framework-extra-bundle": "~3.0"
     },
     "autoload": {
         "psr-0": {
             "QafooLabs\\Bundle\\NoFrameworkBundle\\": "src/",
             "QafooLabs\\MVC\\": "src/"
         }
+    },
+    "suggest": {
+        "symfony/framework-bundle": "~2.1 required",
+        "sensio/framework-extra-bundle": "~3.0 required"
     }
 }


### PR DESCRIPTION
Addressing: https://github.com/QafooLabs/QafooLabsNoFrameworkBundle/issues/10

Removing symfony/framework-bundle as required dependency. Added it as dev dependency, in case there should ever be any tests which depend on framework code and added the dependencies as suggested dependencies.

@beberlei I am not 100% sure if this is the correct way. Somehow this feels kind of wrong.