### PR TITLE
SecurityContextInterface is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phake/phake": "*",
         "symfony/form": "*",
         "jms/serializer": "*",
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "~2.6",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "autoload": {

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
@@ -56,7 +56,8 @@ class ParamConverterListener
                 $value = new SymfonyFormRequest($request, $this->serviceProvider->getFormFactory());
             } else if ("QafooLabs\\MVC\\TokenContext" === $class) {
                 $value = new SymfonyTokenContext(
-                    $this->serviceProvider->getSecurityContext()
+                    $this->serviceProvider->getTokenStorage(),
+                    $this->serviceProvider->getAuthorizationChecker()
                 );
             } else {
                 continue;

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/ParamConverter/ServiceProviderInterface.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/ParamConverter/ServiceProviderInterface.php
@@ -3,6 +3,8 @@
 namespace QafooLabs\Bundle\NoFrameworkBundle\ParamConverter;
 
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 interface ServiceProviderInterface
@@ -13,7 +15,12 @@ interface ServiceProviderInterface
     public function getFormFactory();
 
     /**
-     * @return SecurityContextInterface
+     * @return TokenStorageInterface
      */
-    public function getSecurityContext();
+    public function getTokenStorage();
+
+    /**
+     * @return AuthorizationCheckerInterface
+     */
+    public function getAuthorizationChecker();
 }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/ParamConverter/SymfonyServiceProvider.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/ParamConverter/SymfonyServiceProvider.php
@@ -3,6 +3,8 @@
 namespace QafooLabs\Bundle\NoFrameworkBundle\ParamConverter;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SymfonyServiceProvider implements ServiceProviderInterface
 {
@@ -27,8 +29,16 @@ class SymfonyServiceProvider implements ServiceProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getSecurityContext()
+    public function getTokenStorage()
     {
-        return $this->container->get('security.context');
+        return $this->container->get('security.token_storage');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAuthorizationChecker()
+    {
+        return $this->container->get('security.authorization_checker');
     }
 }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php
@@ -5,17 +5,21 @@ namespace QafooLabs\Bundle\NoFrameworkBundle;
 use QafooLabs\MVC\TokenContext;
 use QafooLabs\MVC\Exception;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class SymfonyTokenContext implements TokenContext
 {
-    private $securityContext;
+    private $tokenStorage;
+    private $authorizationChecker;
 
-    public function __construct(SecurityContextInterface $securityContext)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authorizationChecker)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     /**
@@ -67,7 +71,7 @@ class SymfonyTokenContext implements TokenContext
      */
     public function hasToken()
     {
-        return $this->securityContext->getToken() !== null;
+        return $this->tokenStorage->getToken() !== null;
     }
 
     /**
@@ -88,7 +92,7 @@ class SymfonyTokenContext implements TokenContext
      */
     public function getToken()
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
 
         if ($token === null) {
             throw new Exception\UnauthenticatedUserException();
@@ -102,7 +106,7 @@ class SymfonyTokenContext implements TokenContext
      */
     public function isGranted($attributes, $object = null)
     {
-        return $this->securityContext->isGranted($attributes, $object);
+        return $this->authorizationChecker->isGranted($attributes, $object);
     }
 
     public function assertIsGranted($attributes, $object = null)

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
@@ -21,7 +21,8 @@ class ParamConverterListenerTest extends \PHPUnit_Framework_TestCase
     public function it_converts_parameters()
     {
         $container = new Container;
-        $container->set('security.context', $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface'));
+        $container->set('security.token_storage', \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'));
+        $container->set('security.authorization_checker', \Phake::mock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'));
         $serviceProvider = new SymfonyServiceProvider($container);
 
         $kernel = \Phake::mock('Symfony\Component\HttpKernel\HttpKernelInterface');
@@ -30,16 +31,13 @@ class ParamConverterListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
 
-        $event = new FilterControllerEvent($kernel, array($this, 'someAction'), $request, null);
+        $method = function(Session $session, TokenContext $context, Flash $flash) {};
+        $event = new FilterControllerEvent($kernel, $method, $request, null);
 
         $listener->onKernelController($event);
 
         $this->assertTrue($request->attributes->has('flash'));
         $this->assertTrue($request->attributes->has('context'));
         $this->assertTrue($request->attributes->has('session'));
-    }
-
-    public function someAction(Session $session, TokenContext $context, Flash $flash)
-    {
     }
 }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/SymfonyTokenContextTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/SymfonyTokenContextTest.php
@@ -6,16 +6,23 @@ use QafooLabs\Bundle\NoFrameworkBundle\SymfonyTokenContext;
 
 class SymfonyTokenContextTest extends \PHPUnit_Framework_TestCase
 {
+    private $tokenStorage;
+    private $authorizationChecker;
+    public function setUp()
+    {
+        $this->tokenStorage = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->authorizationChecker = \Phake::mock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        parent::setUp();
+    }
     /**
      * @test
      */
     public function it_retrieves_token_from_security_context()
     {
-        $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
         $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyTokenContext($security, 'dev', true);
+        \Phake::when($this->tokenStorage)->getToken()->thenReturn($token);
 
-        \Phake::when($security)->getToken()->thenReturn($token);
+        $context = new SymfonyTokenContext($this->tokenStorage, $this->authorizationChecker);
 
         $this->assertTrue($context->hasToken());
         $this->assertSame($token, $context->getToken());
@@ -26,9 +33,7 @@ class SymfonyTokenContextTest extends \PHPUnit_Framework_TestCase
      */
     public function it_throws_unauthenticated_user_exception_when_no_token()
     {
-        $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyTokenContext($security, 'dev', true);
+        $context = new SymfonyTokenContext($this->tokenStorage, $this->authorizationChecker);
 
         $this->setExpectedException('QafooLabs\MVC\Exception\UnauthenticatedUserException');
 
@@ -40,9 +45,7 @@ class SymfonyTokenContextTest extends \PHPUnit_Framework_TestCase
      */
     public function it_allows_check_has_token()
     {
-        $security = \Phake::mock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $token = \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $context = new SymfonyTokenContext($security, 'dev', true);
+        $context = new SymfonyTokenContext($this->tokenStorage, $this->authorizationChecker);
 
         $this->assertFalse($context->hasToken());
     }


### PR DESCRIPTION
The interface `\Symfony\Component\Security\Core\SecurityContextInterface` is deprecated, but it's still used
https://github.com/QafooLabs/QafooLabsNoFrameworkBundle/blob/master/src/QafooLabs/Bundle/NoFrameworkBundle/SymfonyTokenContext.php#L16