### PR TITLE
Fix message of BadMethodCallException

### DIFF
--- a/src/QafooLabs/MVC/Form/ValidFormRequest.php
+++ b/src/QafooLabs/MVC/Form/ValidFormRequest.php
@@ -65,7 +65,7 @@ class ValidFormRequest implements FormRequest
      */
     public function getForm()
     {
-        throw new \BadMethodCallException("Not supported in InvalidFormRequest");
+        throw new \BadMethodCallException("Not supported in ValidFormRequest");
     }
 
     /**


### PR DESCRIPTION
Use "Not supported in ValidFormRequest" instead of "Not supported in InvalidFormRequest" as message in ValidFormRequest::getForm