### PR TITLE
Add experimental Turbolinks support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,3 +350,14 @@ application, and prepend the `jms` engine to the configured templating engines:
     framework:
         templating:
             engines: ['jms', 'twig']
+
+## Turbolinks Support
+
+To improve performance with traditional HTML response webapplications Basecamp
+introduced [Turbolinks](https://github.com/turbolinks/turbolinks), a library
+that uses Ajax to follow same domain links and then replaces only head title
+and body to keep javascript and CSS in place.
+
+The QafooLabsNoFrameworkBundle provides out of the box support for the
+turbolinks JS library in the browser by setting the `Turbolinks-Location`
+header after redirects.

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/TurbolinksListener.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/TurbolinksListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace QafooLabs\Bundle\NoFrameworkBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Turbolinks makes navigating your web application faster.
+ *
+ * When you follow a link, Turbolinks automatically fetches the page, swaps in
+ * its <body>, and merges its <head>, all without incurring the cost of a full
+ * page load.
+ *
+ * This Listener handles the server side of Turbolinks by setting the
+ * `Turbolinks-Location' header correctly.
+ *
+ * @link https://github.com/turbolinks/turbolinks
+ */
+class TurbolinksListener
+{
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+        $session = $request->getSession();
+
+        if (!$request->isXmlHttpRequest() || !$session) {
+            return;
+        }
+
+        if ($response->isRedirect() && $request->headers->has('Turbolinks-Referrer')) {
+            $session->set('turbolinks_location', $response->headers->get('Location'));
+        } else if ($session->has('turbolinks_location')) {
+            $response->headers->set('Turbolinks-Location', $session->get('turbolinks_location'));
+            $session->remove('turbolinks_location');
+        }
+    }
+}

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Resources/config/services.xml
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Resources/config/services.xml
@@ -59,5 +59,9 @@
 
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
         </service>
+
+        <service id="qafoo_labs_noframework.turbolinks_listener" class="QafooLabs\Bundle\NoFrameworkBundle\EventListener\TurbolinksListener">
+            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+        </service>
     </services>
 </container>

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/TurbolinksListenerTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/TurbolinksListenerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace QafooLabs\Bundle\NoFrameworkBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+
+use QafooLabs\Bundle\NoFrameworkBundle\EventListener\TurbolinksListener;
+use QafooLabs\MVC\RedirectRouteResponse;
+use QafooLabs\MVC\RedirectRoute;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class TurbolinksListenerTest extends TestCase
+{
+    private $listener;
+
+    public function setUp()
+    {
+        $this->listener = new TurbolinksListener();
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_turbolink_location()
+    {
+        $event = $this->createEventWith($response = new RedirectResponse('/two'));
+        $this->listener->onKernelResponse($event);
+
+        $session = $event->getRequest()->getSession();
+
+        \Phake::verify($session)->set('turbolinks_location', '/two');
+    }
+
+    /**
+     * @test
+     */
+    public function it_passes_turbolinks_location_to_response()
+    {
+        $event = $this->createEventWith($response = new Response());
+
+        $session = $event->getRequest()->getSession();
+        \Phake::when($session)->has('turbolinks_location')->thenReturn(true);
+        \Phake::when($session)->get('turbolinks_location')->thenReturn('/two');
+
+        $this->listener->onKernelResponse($event);
+
+        $this->assertEquals('/two', $response->headers->get('Turbolinks-Location'));
+    }
+
+    private function createEventWith(Response $response)
+    {
+        $request = Request::create('GET', '/');
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+        $request->headers->set('Turbolinks-Referrer', '/');
+        $request->setSession(\Phake::mock(SessionInterface::class));
+
+        return new FilterResponseEvent(
+            \Phake::mock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+    }
+}


### PR DESCRIPTION
This PR adds necessary backend logic to add [turbolinks](https://github.com/turbolinks/turbolinks) support to a Symfony application.

Turbolinks is a javascript library that helps increase performance of applications with server-rendered HTML templates by making Ajax requests of regular requests and switching head `<title>` and `<body>` contents instead of causing full page reloads.

It makes server side rendered applications significantly more smooth and faster.