### PR TITLE
support Action-Domain-Responder (ADR) controllers.

### DIFF
--- a/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/EventListener/ParamConverterListener.php
@@ -31,8 +31,10 @@ class ParamConverterListener
         $controller = $event->getController();
         $request = $event->getRequest();
 
-        if (is_array($controller)) {
+        if (\is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
+        } elseif ($controller instanceof \Closure || \method_exists($controller, '__invoke')) {
+            $r = new \ReflectionMethod($controller, '__invoke');
         } else {
             $r = new \ReflectionFunction($controller);
         }

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/EventListener/ParamConverterListenerTest.php
@@ -3,42 +3,115 @@
 namespace QafooLabs\Bundle\NoFrameworkBundle\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-
 use QafooLabs\Bundle\NoFrameworkBundle\EventListener\ParamConverterListener;
 use QafooLabs\Bundle\NoFrameworkBundle\ParamConverter\SymfonyServiceProvider;
 use QafooLabs\MVC\TokenContext;
-
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+function iAmAController(TokenContext $context): void
+{
+}
 
 class ParamConverterListenerTest extends TestCase
 {
+    private $kernel;
+
+    private $listener;
+
     /**
      * @test
      */
-    public function it_converts_parameters()
+    public function it_converts_parameters(): void
     {
-        $container = new Container;
-        $container->set('security.token_storage', \Phake::mock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'));
-        $container->set('security.authorization_checker', \Phake::mock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'));
-        $serviceProvider = new SymfonyServiceProvider($container);
-
-        $kernel = \Phake::mock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $listener = new ParamConverterListener($serviceProvider);
-
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
 
-        $method = function(Session $session, TokenContext $context) {};
-        $event = new FilterControllerEvent($kernel, $method, $request, HttpKernelInterface::MASTER_REQUEST);
+        $method = function (Session $session, TokenContext $context) {};
+        $event  = new FilterControllerEvent($this->kernel, $method, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $listener->onKernelController($event);
+        $this->listener->onKernelController($event);
 
         $this->assertTrue($request->attributes->has('context'));
         $this->assertTrue($request->attributes->has('session'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_array_contollers(): void
+    {
+        $controller = new class()
+        {
+            public function action(TokenContext $context): void
+            {
+            }
+        };
+        $controller = [$controller, 'action'];
+
+        $this->assertRequestHasContext($controller);
+    }
+
+    /**
+     * @param mixed $controller
+     */
+    private function assertRequestHasContext($controller): void
+    {
+        $request = new Request();
+        $event   = new FilterControllerEvent($this->kernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $this->listener->onKernelController($event);
+
+        $this->assertTrue($request->attributes->has('context'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_invokable_controllers(): void
+    {
+        $controller = new class()
+        {
+            public function __invoke(TokenContext $context)
+            {
+            }
+        };
+
+        $this->assertRequestHasContext($controller);
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_callable_names(): void
+    {
+        $this->assertRequestHasContext('\QafooLabs\Bundle\NoFrameworkBundle\Tests\EventListener\iAmAController');
+    }
+
+    /**
+     * @return array|void
+     */
+    public function setUp(): void
+    {
+        $container = new Container;
+        $container->set(
+          'security.token_storage',
+          \Phake::mock(TokenStorageInterface::class)
+        );
+        $container->set(
+          'security.authorization_checker',
+          \Phake::mock(AuthorizationCheckerInterface::class)
+        );
+        $serviceProvider = new SymfonyServiceProvider($container);
+
+        $this->kernel   = \Phake::mock(HttpKernelInterface::class);
+        $this->listener = new ParamConverterListener($serviceProvider);
+
     }
 }


### PR DESCRIPTION
I use this bundle a lot and currently I'm more and more using ADR Handlers but I figured out, that the param converter doesn't support them.