### PR TITLE
#21: support framework extra bundle template annotation.

### DIFF
--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Resources/config/services.xml
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Resources/config/services.xml
@@ -59,6 +59,12 @@
             <argument type="service" id="qafoo_labs_noframework.controller.name_parser" />
         </service>
 
+        <service id="qafoo_labs_noframework.extra_bundle_interop_template_guesser" class="QafooLabs\Bundle\NoFrameworkBundle\View\ExtraBundleInteropTemplateGuesser"
+            decorates="qafoo_labs_noframework.template_guesser">
+            <argument type="service" id="qafoo_labs_noframework.extra_bundle_interop_template_guesser.inner" />
+            <argument type="service" id="request_stack" />
+        </service>
+
         <service id="qafoo_labs_noframework.bundle_location" class="QafooLabs\Bundle\NoFrameworkBundle\View\BundleLocation">
             <argument type="service" id="kernel" />
         </service>

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/View/ExtraBundleInteropTemplateGuesserTest.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/Tests/View/ExtraBundleInteropTemplateGuesserTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace QafooLabs\Bundle\NoFrameworkBundle\Tests\View;
+
+use QafooLabs\Bundle\NoFrameworkBundle\View\ExtraBundleInteropTemplateGuesser;
+use PHPUnit\Framework\TestCase;
+use QafooLabs\Bundle\NoFrameworkBundle\View\TemplateGuesser;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ExtraBundleInteropTemplateGuesserTest extends TestCase
+{
+    public const ACTION = 'barAction';
+
+    public const CONTROLLER = 'Foo';
+
+    public const ENGINE = 'twig';
+
+    public const FORMAT = 'html';
+
+    public const TEMPLATE = '<my-template>';
+
+    /**
+     * @test
+     * @dataProvider provideNonHandlingRequests
+     */
+    public function delegateOnRequestsWithoutTemplateAttribute(Request $request): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $delegate = $this->prophesize(TemplateGuesser::class);
+
+        $delegate->guessControllerTemplateName(self::CONTROLLER, self::ACTION, self::FORMAT, self::ENGINE)
+                 ->shouldBeCalled()
+                 ->willReturn(self::TEMPLATE)
+        ;
+
+        $guesser = new ExtraBundleInteropTemplateGuesser($delegate->reveal(), $requestStack);
+        self::assertSame(
+          self::TEMPLATE,
+          $guesser->guessControllerTemplateName(self::CONTROLLER, self::ACTION, self::FORMAT, self::ENGINE)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function returnTemplateAttributesTemplateWhenGiven(): void
+    {
+        $templateConfig = $this->prophesize(Template::class);
+        $request = new Request();
+        $request->attributes->set('_template', $templateConfig->reveal());
+
+        $templateConfig->getTemplate()
+                       ->shouldBeCalled()
+                       ->willReturn(self::TEMPLATE)
+        ;
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $delegate = $this->prophesize(TemplateGuesser::class);
+
+        $delegate->guessControllerTemplateName()
+                 ->shouldNotBeCalled()
+        ;
+
+        $guesser = new ExtraBundleInteropTemplateGuesser($delegate->reveal(), $requestStack);
+        self::assertSame(
+          self::TEMPLATE,
+          $guesser->guessControllerTemplateName(self::CONTROLLER, self::ACTION, self::FORMAT, self::ENGINE)
+        );
+    }
+
+    public function provideNonHandlingRequests(): array
+    {
+        $faultyAttributeRequest = new Request();
+        $faultyAttributeRequest->attributes->set('_template', 'foobar');
+
+        return [
+          'simple request' => [new Request()],
+          'request with incompatible template attribute' => [$faultyAttributeRequest],
+        ];
+    }
+}

--- a/src/QafooLabs/Bundle/NoFrameworkBundle/View/ExtraBundleInteropTemplateGuesser.php
+++ b/src/QafooLabs/Bundle/NoFrameworkBundle/View/ExtraBundleInteropTemplateGuesser.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace QafooLabs\Bundle\NoFrameworkBundle\View;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class ExtraBundleInteropTemplateGuesser
+ *
+ * @package QafooLabs\Bundle\NoFrameworkBundle\View
+ */
+class ExtraBundleInteropTemplateGuesser implements TemplateGuesser
+{
+    /** @var TemplateGuesser */
+    private $templateGuesser;
+
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    public function __construct(TemplateGuesser $templateGuesser, RequestStack $requestStack)
+    {
+        $this->templateGuesser = $templateGuesser;
+        $this->requestStack    = $requestStack;
+    }
+
+    /** {@inheritdoc} */
+    public function guessControllerTemplateName($controller, $actionName, $format, $engine)
+    {
+        return $this->detectExtraBundleTemplate() ?:
+          $this->templateGuesser->guessControllerTemplateName(
+            $controller,
+            $actionName,
+            $format,
+            $engine
+          );
+    }
+
+    /**
+     * @return string|null
+     */
+    private function detectExtraBundleTemplate()
+    {
+        $template       = null;
+        $currentRequest = $this->requestStack->getCurrentRequest();
+
+        if ($currentRequest->attributes->has('_template')) {
+            $templateAttr = $currentRequest->attributes->get('_template');
+            if ($templateAttr instanceof Template) {
+                $template = (string)$templateAttr->getTemplate();
+            }
+        }
+
+        return $template;
+    }
+}
+


### PR DESCRIPTION
Added support to work alongside the FrameworkExtraBundle `@Template` annotation.

Decorates the `qafoo_labs_noframework.template_guesser`, so no further configuration may be required.

Closes #21.